### PR TITLE
Replaced add_compile_definitions with add_definitions

### DIFF
--- a/cmake_utils/find_edtpdv.cmake
+++ b/cmake_utils/find_edtpdv.cmake
@@ -23,7 +23,7 @@ mark_as_advanced(EDTPDV_LIBS EDTPDV_INCLUDE_DIRS)
 
 if (EDTPDV_LIBS AND EDTPDV_INCLUDE_DIRS)
     set(EDTPDV_FOUND TRUE)
-	add_compile_definitions(USE_EDTPDV)
+	add_definitions(-DUSE_EDTPDV)
 	message(STATUS "Found EDT PDV Library: " ${EDTPDV_LIBS})
 else()
     message("--- EDT PDV library was not found! ---")


### PR DESCRIPTION
add_compile_definitions was not introduced until cmake 3.12. I am running Ubuntu 18.04, which is convinced that the newest version of cmake is 3.10. Given that we aren't guaranteed to have the newest or most-up-to-date version of anything, I think it makes sense to try to maintain compatibility with cmake < 3.12. 